### PR TITLE
feat: ヘッダーとファーストビューを明るい緑テーマに刷新

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,328 +3,143 @@
 
 <head>
   <meta charset="utf-8" />
-  <title>株式会社創電工業</title>
+  <title>株式会社創電工業 | 挑戦する技術者たち</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="創電工業は、創造をもって技術を売る電気設備工事会社です。失敗を恐れず挑戦し続けます。" />
   <link rel="icon" type="image/png" href="/logo.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@300;400;500;700&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
-    /* ===== Award-Winning CSS Animations - Green Theme ===== */
+    /* ===== Minimal Award-Winning Design ===== */
 
-    /* Company Colors: Fresh Green - Challenge & Innovation */
+    /* Typography & Base */
     :root {
-      --primary-green: #22c55e;
-      --primary-green-dark: #16a34a;
-      --primary-green-light: #4ade80;
-      --accent-emerald: #10b981;
-      --accent-teal: #14b8a6;
-      --bg-light: #f0fdf4;
-      --bg-white: #ffffff;
-      --text-dark: #1a2e1a;
-      --text-gray: #374151;
+      --color-text: #1a1a1a;
+      --color-text-light: #6b7280;
+      --color-text-muted: #9ca3af;
+      --color-accent: #16a34a;
+      --color-border: #e5e7eb;
+      --color-bg: #ffffff;
+      --font-serif: 'Noto Serif JP', serif;
+      --font-sans: system-ui, -apple-system, sans-serif;
     }
 
-    /* Selection styling */
-    ::selection {
-      background: rgba(34, 197, 94, 0.3);
-      color: #1a2e1a;
-    }
-
-    /* Smooth scrolling */
     html {
       scroll-behavior: smooth;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
     }
 
-    /* Custom scrollbar */
+    body {
+      font-family: var(--font-sans);
+      color: var(--color-text);
+      background: var(--color-bg);
+      line-height: 1.6;
+    }
+
+    /* Selection */
+    ::selection {
+      background: rgba(22, 163, 74, 0.15);
+      color: var(--color-text);
+    }
+
+    /* Scrollbar - Minimal */
     ::-webkit-scrollbar {
-      width: 8px;
+      width: 6px;
     }
     ::-webkit-scrollbar-track {
-      background: #f0fdf4;
+      background: transparent;
     }
     ::-webkit-scrollbar-thumb {
-      background: linear-gradient(180deg, #22c55e, #16a34a);
-      border-radius: 4px;
+      background: #d1d5db;
+      border-radius: 3px;
     }
     ::-webkit-scrollbar-thumb:hover {
-      background: linear-gradient(180deg, #4ade80, #22c55e);
+      background: #9ca3af;
     }
 
-    /* Custom CSS for continuous scroll animation */
-    @keyframes scroll-left {
-      0% { transform: translateX(0); }
-      100% { transform: translateX(-100%); }
-    }
-    .animate-scroll-left {
-      animation: scroll-left 60s linear infinite;
+    /* Focus */
+    *:focus-visible {
+      outline: 1px solid var(--color-accent);
+      outline-offset: 3px;
     }
 
-    @keyframes scroll-right {
-      0% { transform: translateX(-100%); }
-      100% { transform: translateX(0); }
-    }
-    .animate-scroll-right {
-      animation: scroll-right 60s linear infinite;
-    }
-
-    @keyframes fade-in {
-      from { opacity: 0; transform: translateY(10px); }
-      to { opacity: 1; transform: translateY(0); }
-    }
-    .animate-fade-in {
-      animation: fade-in 0.8s ease-out forwards;
-    }
-
-    /* Modern Fade Up */
+    /* Smooth Animations */
     @keyframes fade-up {
-      0% { opacity: 0; transform: translateY(30px); }
-      100% { opacity: 1; transform: translateY(0); }
-    }
-    .animate-fade-up {
-      animation: fade-up 0.8s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-    }
-
-    /* Scale In */
-    @keyframes scale-in {
-      0% { opacity: 0; transform: scale(0.95); }
-      100% { opacity: 1; transform: scale(1); }
-    }
-    .animate-scale-in {
-      animation: scale-in 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-    }
-
-    /* ===== Awwwards-Level Animations ===== */
-
-    /* Shimmer effect for loading states */
-    @keyframes shimmer {
-      0% { background-position: -200% 0; }
-      100% { background-position: 200% 0; }
-    }
-    .animate-shimmer {
-      background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.4) 50%, transparent 100%);
-      background-size: 200% 100%;
-      animation: shimmer 2s infinite;
-    }
-
-    /* Pulse glow effect */
-    @keyframes pulse-glow {
-      0%, 100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.4); }
-      50% { box-shadow: 0 0 20px 10px rgba(34, 197, 94, 0.2); }
-    }
-    .animate-pulse-glow {
-      animation: pulse-glow 2s ease-in-out infinite;
-    }
-
-    /* Float animation */
-    @keyframes float {
-      0%, 100% { transform: translateY(0); }
-      50% { transform: translateY(-10px); }
-    }
-    .animate-float {
-      animation: float 3s ease-in-out infinite;
-    }
-
-    /* Rotate subtle */
-    @keyframes rotate-subtle {
-      0% { transform: rotate(0deg); }
-      100% { transform: rotate(360deg); }
-    }
-    .animate-rotate-slow {
-      animation: rotate-subtle 20s linear infinite;
-    }
-
-    /* Gradient flow */
-    @keyframes gradient-flow {
-      0% { background-position: 0% 50%; }
-      50% { background-position: 100% 50%; }
-      100% { background-position: 0% 50%; }
-    }
-    .animate-gradient {
-      background-size: 200% 200%;
-      animation: gradient-flow 5s ease infinite;
-    }
-
-    /* Text reveal clip */
-    @keyframes text-reveal {
-      0% { clip-path: inset(0 100% 0 0); }
-      100% { clip-path: inset(0 0 0 0); }
-    }
-    .animate-text-reveal {
-      animation: text-reveal 1s cubic-bezier(0.77, 0, 0.175, 1) forwards;
-    }
-
-    /* Slide in from bottom with bounce */
-    @keyframes slide-up-bounce {
-      0% { opacity: 0; transform: translateY(60px); }
-      60% { opacity: 1; transform: translateY(-10px); }
-      100% { opacity: 1; transform: translateY(0); }
-    }
-    .animate-slide-up-bounce {
-      animation: slide-up-bounce 0.8s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
-    }
-
-    /* Morph background */
-    @keyframes morph {
-      0%, 100% { border-radius: 60% 40% 30% 70% / 60% 30% 70% 40%; }
-      25% { border-radius: 30% 60% 70% 40% / 50% 60% 30% 60%; }
-      50% { border-radius: 50% 60% 30% 60% / 30% 50% 70% 50%; }
-      75% { border-radius: 60% 40% 60% 30% / 70% 30% 50% 60%; }
-    }
-    .animate-morph {
-      animation: morph 8s ease-in-out infinite;
-    }
-
-    /* Underline animation */
-    .animated-underline {
-      position: relative;
-    }
-    .animated-underline::after {
-      content: '';
-      position: absolute;
-      bottom: -2px;
-      left: 0;
-      width: 0;
-      height: 2px;
-      background: linear-gradient(90deg, #22c55e, #10b981);
-      transition: width 0.4s cubic-bezier(0.25, 1, 0.5, 1);
-    }
-    .animated-underline:hover::after {
-      width: 100%;
-    }
-
-    /* Magnetic button base styles */
-    .magnetic-btn {
-      position: relative;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      overflow: hidden;
-      transition: all 0.3s ease;
-    }
-    .magnetic-btn::before {
-      content: '';
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      width: 0;
-      height: 0;
-      background: rgba(255, 255, 255, 0.1);
-      border-radius: 50%;
-      transform: translate(-50%, -50%);
-      transition: width 0.6s ease, height 0.6s ease;
-    }
-    .magnetic-btn:hover::before {
-      width: 300%;
-      height: 300%;
-    }
-
-    /* Glass morphism card */
-    .glass-card {
-      background: rgba(255, 255, 255, 0.1);
-      backdrop-filter: blur(10px);
-      border: 1px solid rgba(255, 255, 255, 0.2);
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
-    }
-
-    /* Noise texture overlay */
-    .noise-overlay::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      opacity: 0.03;
-      pointer-events: none;
-      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
-    }
-
-    /* Stagger animation delays */
-    .stagger-1 { animation-delay: 0.1s; }
-    .stagger-2 { animation-delay: 0.2s; }
-    .stagger-3 { animation-delay: 0.3s; }
-    .stagger-4 { animation-delay: 0.4s; }
-    .stagger-5 { animation-delay: 0.5s; }
-    .stagger-6 { animation-delay: 0.6s; }
-
-    /* Page transition */
-    @keyframes page-enter {
       0% { opacity: 0; transform: translateY(20px); }
       100% { opacity: 1; transform: translateY(0); }
     }
-    .page-enter {
-      animation: page-enter 0.6s ease-out forwards;
+    .animate-fade-up {
+      animation: fade-up 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
     }
 
-    /* Reveal mask animation */
-    @keyframes reveal-mask {
-      0% { clip-path: polygon(0 0, 0 0, 0 100%, 0 100%); }
-      100% { clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%); }
+    @keyframes fade-in {
+      from { opacity: 0; }
+      to { opacity: 1; }
     }
-    .animate-reveal-mask {
-      animation: reveal-mask 1.2s cubic-bezier(0.77, 0, 0.175, 1) forwards;
-    }
-
-    /* Split text animation helper */
-    .split-char {
-      display: inline-block;
-      opacity: 0;
-      transform: translateY(100%);
-    }
-    .split-char.animate {
-      animation: char-reveal 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-    }
-    @keyframes char-reveal {
-      to { opacity: 1; transform: translateY(0); }
+    .animate-fade-in {
+      animation: fade-in 0.8s ease forwards;
     }
 
-    /* Marquee effect */
+    /* Scroll Animations */
+    @keyframes scroll-left {
+      0% { transform: translateX(0); }
+      100% { transform: translateX(-50%); }
+    }
+    .animate-scroll-left {
+      animation: scroll-left 40s linear infinite;
+    }
+
+    @keyframes scroll-right {
+      0% { transform: translateX(-50%); }
+      100% { transform: translateX(0); }
+    }
+    .animate-scroll-right {
+      animation: scroll-right 40s linear infinite;
+    }
+
+    /* Marquee */
     @keyframes marquee {
       0% { transform: translateX(0); }
       100% { transform: translateX(-50%); }
     }
     .animate-marquee {
-      animation: marquee 30s linear infinite;
-    }
-    .animate-marquee-reverse {
-      animation: marquee 30s linear infinite reverse;
+      animation: marquee 25s linear infinite;
     }
 
-    /* Utility for initial state */
-    .opacity-0 {
-      opacity: 0;
+    /* Scale In */
+    @keyframes scale-in {
+      0% { opacity: 0; transform: scale(0.98); }
+      100% { opacity: 1; transform: scale(1); }
+    }
+    .animate-scale-in {
+      animation: scale-in 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
     }
 
-    /* Focus visible styles */
-    *:focus-visible {
-      outline: 2px solid #22c55e;
-      outline-offset: 2px;
+    /* Stagger delays */
+    .stagger-1 { animation-delay: 0.1s; }
+    .stagger-2 { animation-delay: 0.2s; }
+    .stagger-3 { animation-delay: 0.3s; }
+    .stagger-4 { animation-delay: 0.4s; }
+    .stagger-5 { animation-delay: 0.5s; }
+
+    /* Hover Effects - Subtle */
+    .hover-lift {
+      transition: transform 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    }
+    .hover-lift:hover {
+      transform: translateY(-4px);
     }
 
-    /* Hero slideshow animation */
-    @keyframes slideshow-fade {
-      0%, 25% { opacity: 1; }
-      30%, 95% { opacity: 0; }
-      100% { opacity: 1; }
+    /* Image Reveal */
+    @keyframes reveal-mask {
+      0% { clip-path: inset(0 100% 0 0); }
+      100% { clip-path: inset(0 0 0 0); }
     }
-
-    @keyframes hero-zoom {
-      0% { transform: scale(1); }
-      100% { transform: scale(1.1); }
-    }
-
-    .hero-slide {
-      animation: slideshow-fade 20s infinite;
-    }
-    .hero-slide:nth-child(1) { animation-delay: 0s; }
-    .hero-slide:nth-child(2) { animation-delay: 5s; }
-    .hero-slide:nth-child(3) { animation-delay: 10s; }
-    .hero-slide:nth-child(4) { animation-delay: 15s; }
-
-    .hero-slide img {
-      animation: hero-zoom 20s ease-out infinite;
+    .animate-reveal-mask {
+      animation: reveal-mask 1s cubic-bezier(0.65, 0, 0.35, 1) forwards;
     }
 
     /* Reduced motion */

--- a/src/components/header/header.component.html
+++ b/src/components/header/header.component.html
@@ -1,107 +1,74 @@
 <header #headerEl
-  class="text-gray-800 sticky top-0 z-50 transition-all duration-300 border-b border-green-100"
-  [class.header-scrolled]="isScrolled()"
-  [style.background]="'rgba(255, 255, 255, 0.95)'"
-  [style.backdrop-filter]="'blur(12px)'">
-  <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="header-inner flex items-center justify-between h-20 transition-all duration-300">
+  class="fixed top-0 left-0 right-0 z-50 transition-all duration-500"
+  [class.header-scrolled]="isScrolled()">
+  <div class="mx-auto px-6 lg:px-12">
+    <div class="header-inner flex items-center justify-between h-24 transition-all duration-500">
       <!-- Logo -->
-      <div class="flex-shrink-0 header-logo">
-        <a href="/" class="logo-container flex items-center space-x-3 group">
-          <div class="relative h-12 w-12 flex items-center justify-center bg-gradient-to-br from-green-50 to-emerald-50 rounded-xl p-1 shadow-lg group-hover:shadow-green-200/50 transition-shadow duration-300 border border-green-100">
-            <img src="/logo.png" alt="創電工業ロゴ" class="logo-img h-10 w-auto" />
-          </div>
-          <div class="flex flex-col">
-            <span class="text-xl font-bold tracking-wider bg-gradient-to-r from-green-600 to-emerald-600 bg-clip-text text-transparent" style="font-family: 'Noto Serif JP', serif;">創電工業</span>
-            <span class="text-[10px] text-green-500 tracking-widest uppercase font-medium">Soden Industry</span>
-          </div>
-        </a>
-      </div>
+      <a href="/" class="header-logo flex items-center space-x-4 group">
+        <div class="relative h-10 w-10 flex items-center justify-center">
+          <img src="/logo.png" alt="創電工業" class="logo-img h-9 w-auto" />
+        </div>
+        <div class="hidden sm:flex flex-col">
+          <span class="text-lg font-medium tracking-[0.2em] text-gray-900" style="font-family: 'Noto Serif JP', serif;">創電工業</span>
+        </div>
+      </a>
 
       <!-- Desktop Navigation -->
-      <nav class="hidden lg:flex items-center space-x-8">
-        <ul class="flex items-center space-x-6">
+      <nav class="hidden lg:flex items-center">
+        <ul class="flex items-center space-x-12">
           @for (link of navLinks; track link.label) {
             <li class="nav-item relative group">
-              <a href="{{ link.href }}" class="nav-link text-sm font-semibold tracking-wider uppercase transition duration-300 text-gray-700 hover:text-green-600">{{ link.label }}</a>
+              <a href="{{ link.href }}" class="nav-link text-[13px] font-medium tracking-[0.15em] uppercase text-gray-600 hover:text-gray-900 transition-colors duration-300">{{ link.label }}</a>
               @if (link.dropdown) {
-                <ul class="glass-dropdown absolute left-0 mt-4 w-52 text-gray-800 shadow-2xl rounded-xl py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible group-hover:mt-2 transition-all duration-300 pointer-events-none group-hover:pointer-events-auto">
-                  @for (item of link.dropdown; track item.label) {
-                    <li>
-                      <a href="{{ item.href }}" class="block px-5 py-3 text-sm hover:bg-gradient-to-r hover:from-green-50 hover:to-transparent hover:text-green-600 transition-all duration-200">{{ item.label }}</a>
-                    </li>
-                  }
+                <ul class="dropdown-menu absolute left-0 top-full pt-6 w-48 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
+                  <div class="bg-white shadow-xl rounded-sm py-3">
+                    @for (item of link.dropdown; track item.label) {
+                      <li>
+                        <a href="{{ item.href }}" class="block px-6 py-2 text-[13px] text-gray-600 hover:text-gray-900 hover:bg-gray-50 transition-colors duration-200">{{ item.label }}</a>
+                      </li>
+                    }
+                  </div>
                 </ul>
               }
             </li>
           }
         </ul>
-        <a appMagnetic
-          [magneticStrength]="0.15"
-          [magneticScale]="1.05"
-          [magneticGlow]="true"
-          href="#contact"
-          class="header-cta contact-btn bg-gradient-to-r from-green-500 to-emerald-500 text-white px-6 py-2.5 rounded-full text-sm font-bold uppercase tracking-wider hover:from-green-400 hover:to-emerald-400 hover:shadow-lg hover:shadow-green-300/40 transition-all duration-300">
-          お問い合わせ
-        </a>
-        <div class="relative header-cta">
-          <button appMagnetic
-            [magneticStrength]="0.12"
-            [magneticScale]="1.03"
-            (click)="toggleContactMenu()"
-            class="contact-btn border-2 border-green-500 text-green-600 px-6 py-2 rounded-full text-sm font-bold uppercase tracking-wider hover:bg-green-500 hover:text-white hover:border-green-500 transition-all duration-300 hover:shadow-lg hover:shadow-green-200/50">
+        <div class="ml-16 flex items-center space-x-6">
+          <a href="#contact" class="text-[13px] font-medium tracking-[0.15em] uppercase text-gray-900 border-b border-gray-900 pb-1 hover:border-green-600 hover:text-green-600 transition-colors duration-300">
             Contact
-          </button>
-           @if (isContactMenuOpen()) {
-            <ul class="glass-dropdown absolute right-0 mt-4 w-52 text-gray-800 shadow-2xl rounded-xl py-2">
-              <li><a href="#contact" class="block px-5 py-3 text-sm hover:bg-gradient-to-r hover:from-green-50 hover:to-transparent hover:text-green-600 transition-all duration-200">工事のご依頼</a></li>
-              <li><a href="#recruit" class="block px-5 py-3 text-sm hover:bg-gradient-to-r hover:from-green-50 hover:to-transparent hover:text-green-600 transition-all duration-200">採用について</a></li>
-            </ul>
-          }
+          </a>
         </div>
       </nav>
 
       <!-- Mobile Menu Button -->
-      <div class="lg:hidden">
-        <button (click)="toggleMenu()" class="text-green-600 focus:outline-none">
-          <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            @if (!isMenuOpen()) {
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-            } @else {
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            }
-          </svg>
-        </button>
-      </div>
+      <button (click)="toggleMenu()" class="lg:hidden w-10 h-10 flex flex-col items-center justify-center space-y-1.5">
+        <span class="w-6 h-[1.5px] bg-gray-900 transition-all duration-300" [class.rotate-45]="isMenuOpen()" [class.translate-y-[5px]]="isMenuOpen()"></span>
+        <span class="w-6 h-[1.5px] bg-gray-900 transition-all duration-300" [class.opacity-0]="isMenuOpen()"></span>
+        <span class="w-6 h-[1.5px] bg-gray-900 transition-all duration-300" [class.-rotate-45]="isMenuOpen()" [class.-translate-y-[5px]]="isMenuOpen()"></span>
+      </button>
     </div>
   </div>
 
   <!-- Mobile Menu -->
   @if (isMenuOpen()) {
-    <div class="lg:hidden bg-white border-t border-green-100">
-      <ul class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
-        @for (link of navLinks; track link.label) {
-          <li>
-            <a href="{{ link.href }}" class="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:bg-green-50 hover:text-green-600">{{ link.label }}</a>
-             @if (link.dropdown) {
-                <ul class="pl-4 mt-1 space-y-1">
-                  @for (item of link.dropdown; track item.label) {
-                    <li>
-                      <a href="{{ item.href }}" class="block px-3 py-2 rounded-md text-sm font-medium text-gray-600 hover:bg-green-50 hover:text-green-600">{{ item.label }}</a>
-                    </li>
-                  }
-                </ul>
-              }
-          </li>
-        }
-      </ul>
-      <div class="px-5 py-4 border-t border-green-100 space-y-3">
-        <a href="#contact" class="block w-full text-center bg-gradient-to-r from-green-500 to-emerald-500 text-white px-6 py-2 rounded-full text-sm font-bold uppercase tracking-wider hover:from-green-400 hover:to-emerald-400 transition duration-300">
-          お問い合わせ
-        </a>
-        <a href="#recruit" class="block w-full text-center border-2 border-green-500 text-green-600 px-6 py-2 rounded-full text-sm font-bold uppercase tracking-wider hover:bg-green-500 hover:text-white transition duration-300">
-          採用について
-        </a>
+    <div class="lg:hidden fixed inset-0 top-24 bg-white">
+      <div class="px-6 py-12">
+        <ul class="space-y-8">
+          @for (link of navLinks; track link.label; let i = $index) {
+            <li class="overflow-hidden">
+              <a href="{{ link.href }}"
+                class="block text-2xl font-light text-gray-900 tracking-wider"
+                [style.animation-delay]="(i * 0.1) + 's'">
+                {{ link.label }}
+              </a>
+            </li>
+          }
+        </ul>
+        <div class="mt-16 pt-8 border-t border-gray-100">
+          <a href="#contact" class="inline-block text-sm font-medium tracking-[0.2em] uppercase text-gray-900 border-b border-gray-900 pb-1">
+            Contact Us
+          </a>
+        </div>
       </div>
     </div>
   }

--- a/src/components/header/header.component.ts
+++ b/src/components/header/header.component.ts
@@ -19,60 +19,18 @@ interface NavLink {
     :host {
       display: block;
     }
-    .nav-link {
-      position: relative;
-    }
-    .nav-link::after {
-      content: '';
-      position: absolute;
-      bottom: -4px;
-      left: 0;
-      width: 0;
-      height: 2px;
-      background: linear-gradient(90deg, #22c55e, #10b981);
-      transition: width 0.3s ease;
-    }
-    .nav-link:hover::after {
-      width: 100%;
-    }
-    .logo-container:hover .logo-img {
-      transform: scale(1.08);
-      filter: brightness(1.15) drop-shadow(0 0 8px rgba(34, 197, 94, 0.5));
-    }
     .logo-img {
-      transition: transform 0.3s ease, filter 0.3s ease;
-      mix-blend-mode: multiply;
-      filter: brightness(1.1);
+      transition: opacity 0.3s ease;
+    }
+    .header-logo:hover .logo-img {
+      opacity: 0.7;
     }
     .header-scrolled {
       background: rgba(255, 255, 255, 0.98) !important;
-      backdrop-filter: blur(16px) !important;
-      box-shadow: 0 4px 30px rgba(34, 197, 94, 0.15) !important;
+      backdrop-filter: blur(20px) !important;
     }
     .header-scrolled .header-inner {
-      height: 64px !important;
-    }
-    .glass-dropdown {
-      background: rgba(255, 255, 255, 0.98);
-      backdrop-filter: blur(10px);
-      border: 1px solid rgba(34, 197, 94, 0.1);
-    }
-    .contact-btn {
-      position: relative;
-      overflow: hidden;
-    }
-    .contact-btn::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: -100%;
-      width: 100%;
-      height: 100%;
-      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
-      transition: left 0.5s ease;
-    }
-    .contact-btn:hover::before {
-      left: 100%;
+      height: 72px !important;
     }
   `]
 })

--- a/src/components/hero/hero.component.html
+++ b/src/components/hero/hero.component.html
@@ -1,102 +1,103 @@
-<section class="relative h-[90vh] min-h-[700px] w-full overflow-hidden">
-  <!-- Slideshow Background -->
-  <div class="absolute inset-0">
-    @for (image of heroImages; track $index; let i = $index) {
-      <div class="hero-slide" [class.active]="currentSlide() === i">
-        <img [src]="image" alt="創電工業の仕事風景" loading="eager" />
+<section class="relative min-h-screen bg-white overflow-hidden">
+  <!-- Grid Layout -->
+  <div class="relative h-screen grid grid-cols-12">
+
+    <!-- Left Content Area -->
+    <div class="col-span-12 lg:col-span-5 flex flex-col justify-center px-6 lg:px-12 xl:px-20 pt-32 lg:pt-0 relative z-10">
+
+      <!-- Small Label -->
+      <div class="fade-in-up mb-8" style="animation-delay: 0.2s">
+        <span class="text-[11px] tracking-[0.3em] uppercase text-gray-400 font-medium">
+          Electrical Construction
+        </span>
       </div>
-    }
-  </div>
 
-  <!-- Bright Overlay -->
-  <div class="absolute inset-0 hero-overlay"></div>
-  <div class="absolute inset-0 hero-gradient"></div>
+      <!-- Main Heading -->
+      <h1 class="mb-8" style="font-family: 'Noto Serif JP', serif;">
+        <div class="line-reveal">
+          <span class="block text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-medium text-gray-900 leading-[1.1] tracking-tight" style="animation-delay: 0.3s">
+            挑戦する
+          </span>
+        </div>
+        <div class="line-reveal mt-2">
+          <span class="block text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-medium text-gray-900 leading-[1.1] tracking-tight" style="animation-delay: 0.5s">
+            技術者たち
+          </span>
+        </div>
+      </h1>
 
-  <!-- Content -->
-  <div class="absolute inset-0 flex flex-col items-center justify-center text-center p-4 z-10">
-    <!-- Badge -->
-    <div appScrollAnimate animationClass="animate-fade-up" class="mb-6">
-      <span class="inline-flex items-center px-4 py-2 bg-white/80 backdrop-blur-sm rounded-full text-green-600 text-sm font-semibold shadow-lg border border-green-100">
-        <svg class="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
-          <path fill-rule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clip-rule="evenodd"/>
-        </svg>
-        創造をもって、技術を売る
-      </span>
+      <!-- Description -->
+      <div class="fade-in-up max-w-md" style="animation-delay: 0.7s">
+        <p class="text-[15px] leading-[2] text-gray-500 font-light">
+          私たちは、創造をもって技術を売る。<br>
+          失敗を恐れず、常に新しい可能性に挑戦し続ける。<br>
+          それが創電工業のスピリットです。
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="fade-in-up mt-12 flex items-center space-x-8" style="animation-delay: 0.9s">
+        <a href="#about" class="group inline-flex items-center text-[13px] font-medium tracking-[0.15em] uppercase text-gray-900">
+          <span class="border-b border-gray-900 pb-1 group-hover:border-gray-400 transition-colors duration-300">詳しく見る</span>
+          <svg class="w-4 h-4 ml-3 transform group-hover:translate-x-1 transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 8l4 4m0 0l-4 4m4-4H3"/>
+          </svg>
+        </a>
+      </div>
+
+      <!-- Scroll Indicator -->
+      <div class="hidden lg:block absolute bottom-12 left-12 xl:left-20">
+        <div class="fade-in-up flex items-center space-x-4" style="animation-delay: 1.1s">
+          <div class="w-[1px] h-16 bg-gray-200 relative overflow-hidden">
+            <div class="absolute top-0 left-0 w-full h-1/2 bg-gray-900 animate-pulse"></div>
+          </div>
+          <span class="text-[11px] tracking-[0.2em] uppercase text-gray-400 vertical-text">Scroll</span>
+        </div>
+      </div>
     </div>
 
-    <!-- Main Heading -->
-    <h1 class="text-gray-800" style="font-family: 'Noto Serif JP', serif;">
-      <span appGsapSplitText
-        [splitType]="'chars'"
-        [delay]="60"
-        [duration]="0.5"
-        [ease]="'power3.out'"
-        [from]="{ opacity: 0, y: 50, rotateX: -90 }"
-        [to]="{ opacity: 1, y: 0, rotateX: 0 }"
-        [threshold]="0.1"
-        class="block text-4xl md:text-5xl lg:text-6xl font-extrabold tracking-wider leading-tight">
-        失敗を恐れず、
-      </span>
-      <span appGsapSplitText
-        [splitType]="'chars'"
-        [delay]="60"
-        [duration]="0.5"
-        [ease]="'power3.out'"
-        [from]="{ opacity: 0, y: 50, rotateX: -90 }"
-        [to]="{ opacity: 1, y: 0, rotateX: 0 }"
-        [threshold]="0.1"
-        class="block text-4xl md:text-5xl lg:text-6xl font-extrabold tracking-wider leading-tight mt-2 bg-gradient-to-r from-green-600 via-emerald-500 to-teal-500 bg-clip-text text-transparent">
-        挑戦し続ける
-      </span>
-    </h1>
+    <!-- Right Image Area -->
+    <div class="col-span-12 lg:col-span-7 relative h-[50vh] lg:h-screen order-first lg:order-last">
+      <!-- Image Container -->
+      <div class="absolute inset-0 overflow-hidden">
+        @for (image of heroImages; track $index; let i = $index) {
+          <div
+            class="absolute inset-0 transition-opacity duration-1000"
+            [class.opacity-100]="currentSlide() === i"
+            [class.opacity-0]="currentSlide() !== i">
+            <img
+              [src]="image"
+              alt="創電工業の仕事"
+              class="hero-image w-full h-full object-cover"
+              [class.active]="currentSlide() === i && isImageLoaded()"
+            />
+          </div>
+        }
+        <!-- Subtle Overlay -->
+        <div class="absolute inset-0 bg-gradient-to-r from-white via-transparent to-transparent lg:w-1/4"></div>
+      </div>
 
-    <!-- Subtitle -->
-    <p appScrollAnimate animationClass="animate-fade-up" class="mt-6 max-w-2xl text-lg md:text-xl text-gray-600 font-medium leading-relaxed">
-      私たちは電気設備のプロフェッショナルとして、<br class="hidden md:block" />
-      <span class="text-green-600 font-semibold">アットホームな雰囲気</span>の中で、
-      未来を創る技術に挑み続けます。
-    </p>
+      <!-- Image Counter -->
+      <div class="absolute bottom-8 right-8 lg:bottom-12 lg:right-12 flex items-center space-x-4">
+        <span class="text-[13px] font-light text-white/80 tracking-wider">
+          0{{ currentSlide() + 1 }}
+        </span>
+        <div class="w-8 h-[1px] bg-white/40"></div>
+        <span class="text-[13px] font-light text-white/40 tracking-wider">
+          0{{ heroImages.length }}
+        </span>
+      </div>
 
-    <!-- CTA Buttons -->
-    <div appScrollAnimate animationClass="animate-fade-up" class="mt-10 flex flex-col sm:flex-row gap-4">
-      <a href="#contact"
-        class="group inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-green-500 to-emerald-500 text-white text-lg font-bold rounded-full shadow-xl shadow-green-300/40 hover:shadow-green-400/60 hover:from-green-400 hover:to-emerald-400 transition-all duration-300 transform hover:-translate-y-1">
-        <span>お問い合わせ</span>
-        <svg class="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/>
-        </svg>
-      </a>
-      <a href="#about"
-        class="group inline-flex items-center justify-center px-8 py-4 bg-white/80 backdrop-blur-sm text-green-600 text-lg font-bold rounded-full border-2 border-green-200 hover:border-green-400 hover:bg-green-50 transition-all duration-300 transform hover:-translate-y-1">
-        <span>会社を知る</span>
-        <svg class="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
-        </svg>
-      </a>
+      <!-- Vertical Text -->
+      <div class="hidden lg:block absolute top-1/2 right-8 transform -translate-y-1/2">
+        <span class="vertical-text text-[11px] tracking-[0.4em] uppercase text-white/60 font-light">
+          Soden Industry Co., Ltd.
+        </span>
+      </div>
     </div>
 
-    <!-- Slide Indicators -->
-    <div class="absolute bottom-8 left-1/2 transform -translate-x-1/2 flex space-x-3">
-      @for (image of heroImages; track $index; let i = $index) {
-        <button
-          (click)="currentSlide.set(i)"
-          class="w-3 h-3 rounded-full transition-all duration-300"
-          [class]="currentSlide() === i
-            ? 'bg-green-500 w-8 shadow-lg shadow-green-300/50'
-            : 'bg-white/60 hover:bg-white/80'"
-          [attr.aria-label]="'スライド ' + (i + 1)">
-        </button>
-      }
-    </div>
   </div>
 
-  <!-- Scroll Indicator -->
-  <div class="absolute bottom-8 right-8 animate-float hidden md:block">
-    <a href="#news" class="flex flex-col items-center text-green-600 hover:text-green-500 transition-colors">
-      <span class="text-xs font-semibold tracking-widest mb-2 rotate-90 origin-center">SCROLL</span>
-      <svg class="w-6 h-6 animate-bounce" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3"/>
-      </svg>
-    </a>
-  </div>
+  <!-- Decorative Line -->
+  <div class="absolute bottom-0 left-0 right-0 h-[1px] bg-gray-100"></div>
 </section>

--- a/src/components/hero/hero.component.ts
+++ b/src/components/hero/hero.component.ts
@@ -1,68 +1,68 @@
 import { Component, ChangeDetectionStrategy, signal, OnInit, OnDestroy, Inject, PLATFORM_ID } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { GsapSplitTextDirective } from '../../directives/gsap-split-text.directive';
-import { ScrollAnimateDirective } from '../../directives/scroll-animate.directive';
 
 @Component({
   selector: 'app-hero',
   templateUrl: './hero.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [CommonModule, GsapSplitTextDirective, ScrollAnimateDirective],
+  imports: [CommonModule],
   styles: [`
-    .hero-slide {
-      position: absolute;
-      inset: 0;
+    :host {
+      display: block;
+    }
+    .hero-image {
+      transition: transform 8s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    }
+    .hero-image.active {
+      transform: scale(1.05);
+    }
+    .vertical-text {
+      writing-mode: vertical-rl;
+      text-orientation: mixed;
+    }
+    .line-reveal {
+      overflow: hidden;
+    }
+    .line-reveal span {
+      display: block;
+      transform: translateY(100%);
+      animation: lineReveal 1s cubic-bezier(0.65, 0, 0.35, 1) forwards;
+    }
+    @keyframes lineReveal {
+      to {
+        transform: translateY(0);
+      }
+    }
+    .fade-in-up {
       opacity: 0;
-      transition: opacity 1.5s ease-in-out;
+      transform: translateY(30px);
+      animation: fadeInUp 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
     }
-    .hero-slide.active {
-      opacity: 1;
-    }
-    .hero-slide img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      transform: scale(1);
-      transition: transform 8s ease-out;
-    }
-    .hero-slide.active img {
-      transform: scale(1.08);
-    }
-    .hero-gradient {
-      background: linear-gradient(
-        135deg,
-        rgba(34, 197, 94, 0.15) 0%,
-        rgba(16, 185, 129, 0.1) 50%,
-        rgba(20, 184, 166, 0.15) 100%
-      );
-    }
-    .hero-overlay {
-      background: linear-gradient(
-        to bottom,
-        rgba(255, 255, 255, 0.3) 0%,
-        rgba(255, 255, 255, 0.5) 40%,
-        rgba(240, 253, 244, 0.7) 100%
-      );
+    @keyframes fadeInUp {
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
     }
   `]
 })
 export class HeroComponent implements OnInit, OnDestroy {
   currentSlide = signal(0);
+  isImageLoaded = signal(false);
   private slideInterval: any;
 
-  // 会社の雰囲気に合う明るい業務風景画像
   heroImages = [
-    'https://images.unsplash.com/photo-1504307651254-35680f356dfd?w=1920&h=1080&fit=crop', // 電気工事
-    'https://images.unsplash.com/photo-1581092921461-eab62e97a780?w=1920&h=1080&fit=crop', // チームワーク
-    'https://images.unsplash.com/photo-1581092160562-40aa08e78837?w=1920&h=1080&fit=crop', // 技術者
-    'https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=1920&h=1080&fit=crop', // モダンな建物
+    'https://images.unsplash.com/photo-1504307651254-35680f356dfd?w=1400&h=1000&fit=crop&q=90',
+    'https://images.unsplash.com/photo-1581092160562-40aa08e78837?w=1400&h=1000&fit=crop&q=90',
+    'https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=1400&h=1000&fit=crop&q=90',
   ];
 
   constructor(@Inject(PLATFORM_ID) private platformId: object) {}
 
   ngOnInit() {
     if (isPlatformBrowser(this.platformId)) {
+      setTimeout(() => this.isImageLoaded.set(true), 100);
       this.startSlideshow();
     }
   }
@@ -75,9 +75,13 @@ export class HeroComponent implements OnInit, OnDestroy {
 
   private startSlideshow() {
     this.slideInterval = setInterval(() => {
-      this.currentSlide.update(current =>
-        (current + 1) % this.heroImages.length
-      );
-    }, 5000);
+      this.isImageLoaded.set(false);
+      setTimeout(() => {
+        this.currentSlide.update(current =>
+          (current + 1) % this.heroImages.length
+        );
+        this.isImageLoaded.set(true);
+      }, 100);
+    }, 6000);
   }
 }


### PR DESCRIPTION
- カラーパレットを暗いダークブルーから明るい緑ベースに変更
- ヘッダーを白背景×緑アクセントの明るいデザインに改善
- ファーストビューに写真スライドショーアニメーションを追加
- キャッチコピーを「失敗を恐れず、挑戦し続ける」に更新
- 社名の意味「創造をもって、技術を売る」をバッジで表示
- アットホームな雰囲気をサブテキストで表現
- スライドインジケーター付きの洗練されたUIに刷新