### PR TITLE
[codex] Fix SEO domain references

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "ng serve",
     "build": "ng build",
     "preview": "ng serve --configuration=production",
-    "optimize-images": "node scripts/optimize-images.mjs"
+    "optimize-images": "node scripts/optimize-images.mjs",
+    "test:seo": "node --test tests/deployment-config.test.mjs tests/seo-domain-config.test.mjs"
   },
   "dependencies": {
     "@angular/build": "21.0.5",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -15,4 +15,4 @@ User-agent: Bingbot
 Allow: /
 Disallow: /api/
 
-Sitemap: https://www.soden-kogyo.co.jp/sitemap.xml
+Sitemap: https://soudenkougyou.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,32 +2,32 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
-    <loc>https://www.soden-kogyo.co.jp/</loc>
+    <loc>https://soudenkougyou.com/</loc>
     <lastmod>2026-04-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <image:image>
-      <image:loc>https://www.soden-kogyo.co.jp/images/companyinfo.jpg</image:loc>
+      <image:loc>https://soudenkougyou.com/images/companyinfo.jpg</image:loc>
       <image:title>株式会社創電工業 チーム集合写真</image:title>
     </image:image>
   </url>
   <url>
-    <loc>https://www.soden-kogyo.co.jp/company</loc>
+    <loc>https://soudenkougyou.com/company</loc>
     <lastmod>2026-04-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <image:image>
-      <image:loc>https://www.soden-kogyo.co.jp/images/CEO.JPG</image:loc>
+      <image:loc>https://soudenkougyou.com/images/CEO.JPG</image:loc>
       <image:title>代表取締役社長 上野 衆</image:title>
     </image:image>
   </url>
   <url>
-    <loc>https://www.soden-kogyo.co.jp/recruit</loc>
+    <loc>https://soudenkougyou.com/recruit</loc>
     <lastmod>2026-04-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <image:image>
-      <image:loc>https://www.soden-kogyo.co.jp/images/recruit_hero_bright.jpg</image:loc>
+      <image:loc>https://soudenkougyou.com/images/recruit_hero_bright.jpg</image:loc>
       <image:title>株式会社創電工業 採用情報</image:title>
     </image:image>
   </url>

--- a/tests/seo-domain-config.test.mjs
+++ b/tests/seo-domain-config.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CANONICAL_ORIGIN = 'https://soudenkougyou.com';
+const LEGACY_ORIGIN = 'https://www.soden-kogyo.co.jp';
+
+function readPublicFile(fileName) {
+  return fs.readFileSync(path.resolve('public', fileName), 'utf8');
+}
+
+test('robots.txt points to the canonical sitemap origin', () => {
+  const robots = readPublicFile('robots.txt');
+
+  assert.match(robots, new RegExp(`Sitemap:\\s*${CANONICAL_ORIGIN}/sitemap\\.xml`));
+  assert.doesNotMatch(robots, new RegExp(LEGACY_ORIGIN.replaceAll('.', '\\.')));
+});
+
+test('sitemap.xml only lists canonical soudenkougyou.com URLs', () => {
+  const sitemap = readPublicFile('sitemap.xml');
+  const urls = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) => match[1]);
+
+  assert.ok(urls.length > 0, 'Expected sitemap.xml to contain at least one URL');
+
+  for (const url of urls) {
+    assert.match(url, new RegExp(`^${CANONICAL_ORIGIN.replaceAll('.', '\\.')}(?:/|$)`));
+    assert.doesNotMatch(url, new RegExp(LEGACY_ORIGIN.replaceAll('.', '\\.')));
+  }
+});


### PR DESCRIPTION
## Summary
- replace legacy `www.soden-kogyo.co.jp` sitemap references with `https://soudenkougyou.com`
- add a focused SEO regression test to keep `robots.txt` and `sitemap.xml` aligned with the canonical domain
- add a single `npm run test:seo` entry point for deployment-related SEO checks

## Root Cause
The repository was still publishing legacy-domain URLs from `public/robots.txt` and `public/sitemap.xml`. That can cause Search Console to evaluate old-domain URLs instead of the canonical `soudenkougyou.com` URLs.

## Validation
- `npm run test:seo`
- `npm run build`

## Notes
- `vercel.json` was intentionally left unchanged because this repository is currently configured as an SPA and still relies on the catch-all rewrite for direct route access.
- This PR does not add a new `/services` route; it only fixes canonical domain references already shipped by the current repo.