### PR TITLE
Fix services page indexing and canonical SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
+  <base href="/" />
   <title>株式会社創電工業 | 電気設備工事・設計施工（青森県八戸市）</title>
   <meta name="description" content="青森県八戸市の株式会社創電工業。電気設備工事・電気通信工事・消防設備・空調設備・太陽光発電・物流システムの設計施工から保守管理まで対応。1987年創業、地域密着38年の実績と信頼。" />
   <meta name="keywords" content="創電工業,電気工事,電気設備工事,電気通信工事,消防設備,空調設備,太陽光発電,物流システム,設計施工,保守管理,八戸市,青森県,電気工事士,施工管理,SDGs,再生可能エネルギー" />
@@ -19,8 +20,8 @@
   <meta property="og:site_name" content="株式会社創電工業" />
   <meta property="og:title" content="株式会社創電工業 | 電気設備工事・設計施工（青森県八戸市）" />
   <meta property="og:description" content="青森県八戸市の株式会社創電工業。電気設備工事・電気通信工事・消防設備・空調設備・太陽光発電・物流システムの設計施工から保守管理まで対応。1987年創業、地域密着38年の実績と信頼。" />
-  <meta property="og:url" content="https://www.soden-kogyo.co.jp/" />
-  <meta property="og:image" content="https://www.soden-kogyo.co.jp/images/companyinfo.jpg" />
+  <meta property="og:url" content="https://soudenkougyou.com/" />
+  <meta property="og:image" content="https://soudenkougyou.com/images/companyinfo.jpg" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta property="og:image:alt" content="株式会社創電工業 チーム集合写真" />
@@ -29,10 +30,10 @@
   <meta name="twitter:title" content="株式会社創電工業 | 電気設備工事・設計施工（青森県八戸市）" />
   <meta name="twitter:description"
     content="青森県八戸市の株式会社創電工業。電気設備工事・電気通信工事・消防設備・空調設備・太陽光発電・物流システムの設計施工から保守管理まで対応。1987年創業、地域密着38年の実績と信頼。" />
-  <meta name="twitter:image" content="https://www.soden-kogyo.co.jp/images/companyinfo.jpg" />
+  <meta name="twitter:image" content="https://soudenkougyou.com/images/companyinfo.jpg" />
   <meta name="twitter:image:alt" content="株式会社創電工業 チーム集合写真" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="canonical" href="https://www.soden-kogyo.co.jp/" />
+  <link rel="canonical" href="https://soudenkougyou.com/" />
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
   <link rel="apple-touch-icon" href="/logo.png" />

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "ng serve",
-    "build": "ng build",
+    "build": "ng build && node scripts/generate-static-routes.mjs",
     "preview": "ng serve --configuration=production",
     "optimize-images": "node scripts/optimize-images.mjs",
-    "test:seo": "node --test tests/deployment-config.test.mjs tests/seo-domain-config.test.mjs"
+    "test:seo": "node --test tests/deployment-config.test.mjs tests/seo-domain-config.test.mjs tests/seo-route-config.test.mjs"
   },
   "dependencies": {
     "@angular/build": "21.0.5",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -12,6 +12,16 @@
     </image:image>
   </url>
   <url>
+    <loc>https://soudenkougyou.com/services</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+    <image:image>
+      <image:loc>https://soudenkougyou.com/images/elct1.jpg</image:loc>
+      <image:title>株式会社創電工業 事業内容</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://soudenkougyou.com/company</loc>
     <lastmod>2026-04-06</lastmod>
     <changefreq>monthly</changefreq>

--- a/scripts/generate-static-routes.mjs
+++ b/scripts/generate-static-routes.mjs
@@ -1,0 +1,59 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const distDir = path.resolve('dist');
+const sourcePath = path.join(distDir, 'index.html');
+
+const routePages = [
+  {
+    route: 'services',
+    title: '事業内容 | 株式会社創電工業（青森県八戸市）',
+    description: '株式会社創電工業の事業内容。電気設備工事・電気通信工事・消防設備・空調設備・太陽光発電・物流システムの設計施工から保守管理まで、青森県八戸市を拠点に一貫対応します。',
+    keywords: '事業内容,サービス,電気設備工事,電気通信工事,消防設備,空調設備,太陽光発電,物流システム,保守管理,八戸市,青森県,創電工業',
+    image: 'https://soudenkougyou.com/images/elct1.jpg',
+    imageAlt: '株式会社創電工業の事業内容'
+  }
+];
+
+function replaceTag(html, pattern, replacement, missingMessage) {
+  if (!pattern.test(html)) {
+    throw new Error(missingMessage);
+  }
+  return html.replace(pattern, replacement);
+}
+
+function buildPageHtml(sourceHtml, page) {
+  const pageUrl = `https://soudenkougyou.com/${page.route}`;
+
+  let html = sourceHtml;
+  html = replaceTag(html, /<title>.*?<\/title>/s, `<title>${page.title}</title>`, 'Missing <title> tag');
+  html = replaceTag(html, /<meta name="description" content="[^"]*"\s*\/?>/, `<meta name="description" content="${page.description}">`, 'Missing description meta tag');
+  html = replaceTag(html, /<meta name="keywords" content="[^"]*"\s*\/?>/, `<meta name="keywords" content="${page.keywords}">`, 'Missing keywords meta tag');
+  html = replaceTag(html, /<meta property="og:title" content="[^"]*"\s*\/?>/, `<meta property="og:title" content="${page.title}">`, 'Missing og:title meta tag');
+  html = replaceTag(html, /<meta property="og:description" content="[^"]*"\s*\/?>/, `<meta property="og:description" content="${page.description}">`, 'Missing og:description meta tag');
+  html = replaceTag(html, /<meta property="og:url" content="[^"]*"\s*\/?>/, `<meta property="og:url" content="${pageUrl}">`, 'Missing og:url meta tag');
+  html = replaceTag(html, /<meta property="og:image" content="[^"]*"\s*\/?>/, `<meta property="og:image" content="${page.image}">`, 'Missing og:image meta tag');
+  html = replaceTag(html, /<meta property="og:image:alt" content="[^"]*"\s*\/?>/, `<meta property="og:image:alt" content="${page.imageAlt}">`, 'Missing og:image:alt meta tag');
+  html = replaceTag(html, /<meta name="twitter:title" content="[^"]*"\s*\/?>/, `<meta name="twitter:title" content="${page.title}">`, 'Missing twitter:title meta tag');
+  html = replaceTag(html, /<meta name="twitter:description" content="[^"]*"\s*\/?>/, `<meta name="twitter:description" content="${page.description}">`, 'Missing twitter:description meta tag');
+  html = replaceTag(html, /<meta name="twitter:image" content="[^"]*"\s*\/?>/, `<meta name="twitter:image" content="${page.image}">`, 'Missing twitter:image meta tag');
+  html = replaceTag(html, /<meta name="twitter:image:alt" content="[^"]*"\s*\/?>/, `<meta name="twitter:image:alt" content="${page.imageAlt}">`, 'Missing twitter:image:alt meta tag');
+  html = replaceTag(html, /<link rel="canonical" href="[^"]*"\s*\/?>/, `<link rel="canonical" href="${pageUrl}">`, 'Missing canonical link tag');
+
+  return html;
+}
+
+async function main() {
+  const sourceHtml = await fs.readFile(sourcePath, 'utf8');
+
+  for (const page of routePages) {
+    const outputDir = path.join(distDir, page.route);
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(path.join(outputDir, 'index.html'), buildPageHtml(sourceHtml, page), 'utf8');
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -353,6 +353,7 @@ export class AppComponent {
     const pathname = new URL(url).pathname;
     if (pathname !== '/' && pathname !== '') {
       const pathNames: Record<string, string> = {
+        '/services': '事業内容',
         '/company': '会社概要',
         '/recruit': '採用情報'
       };

--- a/src/app.routes.ts
+++ b/src/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { HomeComponent } from './components/home/home.component';
 import { CompanyDetailsComponent } from './components/company-details/company-details.component';
 import { RecruitDetailsComponent } from './components/recruit-details/recruit-details.component';
+import { ServicesDetailsComponent } from './components/services-details/services-details.component';
 
 export const routes: Routes = [
   {
@@ -13,6 +14,17 @@ export const routes: Routes = [
       keywords: '創電工業,電気工事,電気設備工事,電気通信工事,消防設備,空調設備,太陽光発電,物流システム,設計施工,保守管理,八戸市,青森県,電気工事会社,八戸電気工事,青森電気工事,ビル管理,施工管理',
       image: '/images/companyinfo.jpg',
       imageAlt: '株式会社創電工業 チーム集合写真'
+    }
+  },
+  {
+    path: 'services',
+    component: ServicesDetailsComponent,
+    data: {
+      title: '事業内容 | 株式会社創電工業（青森県八戸市）',
+      description: '株式会社創電工業の事業内容。電気設備工事・電気通信工事・消防設備・空調設備・太陽光発電・物流システムの設計施工から保守管理まで、青森県八戸市を拠点に一貫対応します。',
+      keywords: '事業内容,サービス,電気設備工事,電気通信工事,消防設備,空調設備,太陽光発電,物流システム,保守管理,八戸市,青森県,創電工業',
+      image: '/images/elct1.jpg',
+      imageAlt: '株式会社創電工業の事業内容'
     }
   },
   {

--- a/src/components/header/header.component.ts
+++ b/src/components/header/header.component.ts
@@ -46,7 +46,7 @@ export class HeaderComponent implements AfterViewInit {
 
   navLinks: NavLink[] = [
     { label: 'ホーム', labelEn: 'HOME', routerLink: '/' },
-    { label: '私たちの仕事', labelEn: 'SERVICE', routerLink: '/', fragment: 'what-we-do' },
+    { label: '私たちの仕事', labelEn: 'SERVICE', routerLink: '/services' },
     { label: '施工事例', labelEn: 'WORKS', routerLink: '/', fragment: 'cases' },
     { label: '会社案内', labelEn: 'COMPANY', routerLink: '/company' },
     { label: '採用情報', labelEn: 'RECRUIT', routerLink: '/recruit' },

--- a/src/components/services-details/services-details.component.html
+++ b/src/components/services-details/services-details.component.html
@@ -1,0 +1,52 @@
+<main class="bg-white">
+  <section class="relative overflow-hidden bg-slate-950 text-white">
+    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(16,185,129,0.18),_transparent_45%),radial-gradient(circle_at_left,_rgba(14,165,233,0.18),_transparent_40%)]"></div>
+    <div class="relative container mx-auto px-4 sm:px-6 lg:px-8 py-24 lg:py-32">
+      <p class="mb-4 text-sm font-bold tracking-[0.35em] text-emerald-300 uppercase">Services</p>
+      <h1 class="max-w-4xl text-4xl md:text-6xl font-black leading-tight" style="font-family: 'Noto Serif JP', serif;">
+        創電工業の事業内容
+      </h1>
+      <p class="mt-8 max-w-3xl text-base md:text-xl leading-8 text-slate-200">
+        電気設備工事、電気通信工事、消防設備、空調設備、太陽光発電、物流システムまで。
+        設計施工から保守管理まで一貫して対応し、青森県八戸市を拠点に現場の安全と稼働を支えています。
+      </p>
+      <div class="mt-10 flex flex-wrap gap-4">
+        <a
+          routerLink="/"
+          fragment="contact"
+          class="inline-flex items-center rounded-full bg-emerald-400 px-6 py-3 text-sm font-bold text-slate-950 transition hover:bg-emerald-300"
+        >
+          お問い合わせ
+        </a>
+        <a
+          routerLink="/company"
+          class="inline-flex items-center rounded-full border border-white/20 px-6 py-3 text-sm font-bold text-white transition hover:border-white/40 hover:bg-white/5"
+        >
+          会社概要を見る
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <section class="border-y border-slate-200 bg-slate-50">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-10">
+      <div class="grid gap-4 md:grid-cols-3">
+        <div class="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200">
+          <p class="text-sm font-bold tracking-[0.2em] text-emerald-600 uppercase">Electrical</p>
+          <p class="mt-3 text-lg font-bold text-slate-900">受変電設備から弱電設備まで設計施工</p>
+        </div>
+        <div class="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200">
+          <p class="text-sm font-bold tracking-[0.2em] text-emerald-600 uppercase">Maintenance</p>
+          <p class="mt-3 text-lg font-bold text-slate-900">保守点検とトラブル予防で稼働を維持</p>
+        </div>
+        <div class="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200">
+          <p class="text-sm font-bold tracking-[0.2em] text-emerald-600 uppercase">Automation</p>
+          <p class="mt-3 text-lg font-bold text-slate-900">物流・機械設備の電気制御まで一括対応</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <app-what-we-do />
+  <app-contact />
+</main>

--- a/src/components/services-details/services-details.component.ts
+++ b/src/components/services-details/services-details.component.ts
@@ -1,0 +1,14 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { WhatWeDoComponent } from '../what-we-do/what-we-do.component';
+import { ContactComponent } from '../contact/contact.component';
+
+@Component({
+  selector: 'app-services-details',
+  standalone: true,
+  imports: [CommonModule, RouterLink, WhatWeDoComponent, ContactComponent],
+  templateUrl: './services-details.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ServicesDetailsComponent {}

--- a/tests/seo-route-config.test.mjs
+++ b/tests/seo-route-config.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CANONICAL_ORIGIN = 'https://soudenkougyou.com';
+const LEGACY_ORIGIN = 'https://www.soden-kogyo.co.jp';
+
+function readText(relativePath) {
+  return fs.readFileSync(path.resolve(relativePath), 'utf8');
+}
+
+test('index.html uses the canonical soudenkougyou.com homepage URL', () => {
+  const html = readText('index.html');
+
+  assert.match(html, /<link rel="canonical" href="https:\/\/soudenkougyou\.com\/"/);
+  assert.match(html, /<meta property="og:url" content="https:\/\/soudenkougyou\.com\/"/);
+  assert.doesNotMatch(html, new RegExp(LEGACY_ORIGIN.replaceAll('.', '\\.')));
+});
+
+test('application routes include a dedicated /services page', () => {
+  const routesSource = readText('src/app.routes.ts');
+
+  assert.match(routesSource, /path:\s*'services'/);
+});
+
+test('vercel.json rewrites /services to a dedicated static HTML entry', () => {
+  const vercelConfig = JSON.parse(readText('vercel.json'));
+
+  assert.ok(
+    (vercelConfig.rewrites ?? []).some(
+      (rewrite) => rewrite.source === '/services' && rewrite.destination === '/services/index.html'
+    ),
+    'Expected vercel.json to rewrite /services to /services/index.html'
+  );
+});

--- a/vercel.json
+++ b/vercel.json
@@ -50,6 +50,7 @@
     }
   ],
   "rewrites": [
+    { "source": "/services", "destination": "/services/index.html" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- fix the default homepage canonical and OG metadata to use `https://soudenkougyou.com`
- add a dedicated `/services` Angular route with page-specific SEO metadata
- generate `dist/services/index.html` after build and rewrite `/services` to that static entry on Vercel
- add `/services` to the sitemap and cover the routing/meta behavior with SEO regression tests

## Why
Search Console reported `ページにリダイレクトがあります` for `/services`. The site was returning the SPA shell for `/services`, then the Angular wildcard route redirected to `/`, so Google was effectively seeing a redirect-like outcome instead of a stable page. The initial HTML also still carried the old domain in canonical and OG tags.

## Verification
- `npm run test:seo`
- `npm run build`
- confirmed `dist/services/index.html` contains:
  - title: `事業内容 | 株式会社創電工業（青森県八戸市）`
  - canonical: `https://soudenkougyou.com/services`
  - `og:url`: `https://soudenkougyou.com/services`
